### PR TITLE
Support configuration for non-core entities

### DIFF
--- a/src/client/adapter/index.js
+++ b/src/client/adapter/index.js
@@ -8,7 +8,7 @@ import map from 'ramda/src/map.js';
 import path from 'ramda/src/path.js';
 import reduce from 'ramda/src/reduce.js';
 import client from '../index.js';
-import entities, { entityMethods } from '../../entities.js';
+import defaultEntities, { entityMethods } from '../../entities.js';
 import {
   generateFilterTransforms, transformD9Schema, transformLocalEntity,
   transformFetchResponse, transformSendResponse,
@@ -75,13 +75,19 @@ const aggregateBundles = reduce((aggregate, result) => {
 }, { data: [], fulfilled: [], rejected: [] });
 
 /**
+ * @typedef {import('../../entities.js').EntityConfig} EntityConfig
+ */
+/**
  * @param {import('../../model/index').FarmModel} model
  * @param {Object} opts
+ * @property {Object<String, EntityConfig>} [opts.entities=defaultEntities]
  * @returns {import('../index.js').FarmClient}
  */
 export default function adapter(model, opts) {
-  const { host, maxPageLimit = DRUPAL_PAGE_LIMIT, ...rest } = opts;
-  const connection = client(host, rest);
+  const {
+    host, maxPageLimit = DRUPAL_PAGE_LIMIT, entities = defaultEntities, ...rest
+  } = opts;
+  const connection = client(host, { ...rest, entities });
   const initSchemata = model.schema.get();
   let filterTransforms = generateFilterTransforms(initSchemata);
   model.schema.on('set', (schemata) => {

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -3,7 +3,7 @@ import deleteEntity from './delete.js';
 import fetchEntity from './fetch.js';
 import sendEntity from './send.js';
 import oauth from './oauth.js';
-import entities, { entityMethods } from '../entities.js';
+import defaultEntities, { entityMethods } from '../entities.js';
 import fetchSchema from './schema.js';
 
 /** The methods for transmitting farmOS data structures, such as assets, logs,
@@ -40,11 +40,16 @@ import fetchSchema from './schema.js';
  */
 
 /**
+ * @typedef {import('../entities.js').EntityConfig} EntityConfig
+ */
+
+/**
  * Create a farm client for interacting with farmOS servers.
  * @typedef {Function} client
  * @param {String} host
  * @param {Object} [options]
  * @property {AuthMixin=OAuthMixin} [options.auth=oauth]
+ * @property {Object<String, EntityConfig>} [options.entities=defaultEntities]
  * @property {String} [options.clientId]
  * @property {Function} [options.getToken]
  * @property {Function} [options.setToken]
@@ -53,6 +58,7 @@ import fetchSchema from './schema.js';
 export default function client(host, options) {
   const {
     auth = oauth,
+    entities = defaultEntities,
     ...authOptions
   } = options;
 
@@ -75,7 +81,7 @@ export default function client(host, options) {
       return request('/api');
     },
     schema: {
-      fetch: fetchSchema(request),
+      fetch: fetchSchema(request, entities),
     },
     ...entityMethods(({ nomenclature: { name } }) => ({
       delete: deleteEntity(name, request),

--- a/src/client/schema.js
+++ b/src/client/schema.js
@@ -1,7 +1,6 @@
 import map from 'ramda/src/map.js';
 import prop from 'ramda/src/prop.js';
 import typeToBundle from './type-to-bundle.js';
-import entities from '../entities.js';
 
 /**
  * Fetch JSON Schema documents for farmOS data structures.
@@ -10,11 +9,17 @@ import entities from '../entities.js';
  * @param {string} [bundle] The entity bundle for which you wish to retrieve schemata.
  * @returns {Promise<EntitySchemata|BundleSchemata|JsonSchema>}
  */
+
+/**
+ * @typedef {import('../entities.js').EntityConfig} EntityConfig
+ */
+
 /**
  * @param {import('axios').AxiosInstance} request
+ * @param {Object<String, EntityConfig>} entities
  * @returns {FetchSchema}
  */
-const fetchSchema = request => (entity, bundle) => {
+const fetchSchema = (request, entities) => (entity, bundle) => {
   if (!entity) {
     const schemata = map(() => ({}), entities);
     return request('/api/')

--- a/src/entities.js
+++ b/src/entities.js
@@ -52,6 +52,15 @@ export const defaultOptions = { byType, byFormat };
  */
 
 /** @type {Object.<String, EntityConfig>} */
+/**
+ * @typedef {Object.<String, EntityConfig>} DefaultEntities
+ * @property {EntityConfig} asset
+ * @property {EntityConfig} log
+ * @property {EntityConfig} plan
+ * @property {EntityConfig} quantity
+ * @property {EntityConfig} taxonomy_term
+ * @property {EntityConfig} user
+ */
 export default {
   asset: {
     nomenclature: {

--- a/src/entities.js
+++ b/src/entities.js
@@ -9,6 +9,7 @@ const byType = {
 const byFormat = {
   'date-time': () => new Date().toISOString(),
 };
+export const defaultOptions = { byType, byFormat };
 
 /**
  * @typedef {Object} EntityReference
@@ -61,10 +62,7 @@ export default {
       display: 'Asset',
       displayPlural: 'Assets',
     },
-    defaultOptions: {
-      byType,
-      byFormat,
-    },
+    defaultOptions,
   },
   log: {
     nomenclature: {
@@ -75,10 +73,7 @@ export default {
       display: 'Log',
       displayPlural: 'Logs',
     },
-    defaultOptions: {
-      byType,
-      byFormat,
-    },
+    defaultOptions,
   },
   plan: {
     nomenclature: {
@@ -89,10 +84,7 @@ export default {
       display: 'Plan',
       displayPlural: 'Plans',
     },
-    defaultOptions: {
-      byType,
-      byFormat,
-    },
+    defaultOptions,
   },
   quantity: {
     nomenclature: {
@@ -103,10 +95,7 @@ export default {
       display: 'Quantity',
       displayPlural: 'Quantities',
     },
-    defaultOptions: {
-      byType,
-      byFormat,
-    },
+    defaultOptions,
   },
   taxonomy_term: {
     nomenclature: {
@@ -117,10 +106,7 @@ export default {
       display: 'Taxonomy Term',
       displayPlural: 'Taxonomy Terms',
     },
-    defaultOptions: {
-      byType,
-      byFormat,
-    },
+    defaultOptions,
   },
   user: {
     nomenclature: {
@@ -131,10 +117,7 @@ export default {
       display: 'User',
       displayPlural: 'Users',
     },
-    defaultOptions: {
-      byType,
-      byFormat,
-    },
+    defaultOptions,
   },
 };
 

--- a/src/index.js
+++ b/src/index.js
@@ -42,20 +42,25 @@ export { default as model } from './model/index.js';
  * @property {FarmEntityMethods} user
  */
 
+/**
+ * To enable support for each entity type, its config object must be provided.
+ * @typedef {import('./entities.js').EntityConfig} EntityConfig
+ */
+
 /** The main farmOS factory function for creating a new farm object.
  * @typedef {Function} farmOS
  * @param {Object} farmConfig
  * @property {import('./model/index.js').EntitySchemata} [config.schemata]
  * @property {Object} [config.remote]
  * @property {import('./client/index.js').client} [config.remote.adapter=d9JsonApiAdapter]
- * @property {Array<import('./entities.js').EntityConfig>} [config.entities]
+ * @property {Object.<String, EntityConfig>} [config.entities=defaultEntities]
  * @returns {FarmObject}
  */
 export default function farmOS(farmConfig) {
   const { schemata, remote, entities = defaultEntities } = farmConfig;
   const shortNames = Object.values(entities).map(e => e.nomenclature.shortName);
 
-  const farm = /** @type {FarmObject} */ (model({ schemata }));
+  const farm = /** @type {FarmObject} */ (model({ schemata, entities }));
 
   const addRemote = (remoteConfig = {}) => {
     const { adapter = d9JsonApiAdapter, ...options } = remoteConfig;
@@ -68,7 +73,7 @@ export default function farmOS(farmConfig) {
     });
     farm.remote = { ...omit(shortNames, connection), add: addRemote };
   };
-  addRemote(remote);
+  addRemote({ ...remote, entities });
 
   return farm;
 }

--- a/src/model/create.js
+++ b/src/model/create.js
@@ -1,7 +1,6 @@
 import { validate, v4 as uuidv4 } from 'uuid';
 import clone from 'ramda/src/clone.js';
 import { getDefault, listProperties } from '../json-schema/index.js';
-import entities from '../entities.js';
 
 /**
  * @typedef {import('../entities.js').Entity} Entity
@@ -20,7 +19,7 @@ import entities from '../entities.js';
  * @param {import('./index.js').BundleSchemata} schemata
  * @returns {createEntity}
  */
-const createEntity = (entName, schemata) => (props) => {
+const createEntity = (entName, schemata, defaultOptions) => (props) => {
   const { id = uuidv4(), type } = props;
   if (!validate(id)) { throw new Error(`Invalid ${entName} id: ${id}`); }
   const schema = schemata[entName][type];
@@ -41,7 +40,6 @@ const createEntity = (entName, schemata) => (props) => {
     } = {},
   } = meta;
   const fieldChanges = {};
-  const { [entName]: { defaultOptions } } = entities;
   const initFields = (fieldType) => {
     const fields = {};
     listProperties(schema, fieldType).forEach((name) => {

--- a/src/model/index.js
+++ b/src/model/index.js
@@ -4,7 +4,7 @@ import map from 'ramda/src/map.js';
 import createEntity from './create.js';
 import mergeEntity from './merge.js';
 import updateEntity from './update.js';
-import entities, { entityMethods } from '../entities.js';
+import defaultEntities, { entityMethods } from '../entities.js';
 import { dereference } from '../json-schema/reference.js';
 import { createObserver } from '../utils.js';
 
@@ -53,16 +53,20 @@ import { createObserver } from '../utils.js';
  * @property {ModelEntityMethods} user
  */
 
-const entityNames = Object.keys(entities);
-
+/**
+ * @typedef {import('../entities.js').EntityConfig} EntityConfig
+ */
 /**
  * Create a farm model for generating and manipulating farmOS data structures.
  * @typedef {Function} model
  * @param {Object} options
  * @property {EntitySchemata} [options.schemata]
+ * @property {Object<String, EntityConfig>} [options.entities=defaultEntities]
  * @returns {FarmModel}
  */
 export default function model(options = {}) {
+  const { entities = defaultEntities } = options;
+  const entityNames = Object.keys(entities);
   const schemata = map(() => ({}), entities);
 
   const observers = {
@@ -142,8 +146,8 @@ export default function model(options = {}) {
         return lastSync === null || changed > lastSync;
       },
     },
-    ...entityMethods(({ nomenclature: { name } }) => ({
-      create: createEntity(name, schemata),
+    ...entityMethods(({ nomenclature: { name }, defaultOptions }) => ({
+      create: createEntity(name, schemata, defaultOptions),
       merge: mergeEntity(name, schemata),
       update: updateEntity(name, schemata),
     }), entities),


### PR DESCRIPTION
This was done largely as an effort to support the [`farm_profile`](https://github.com/mstenta/farm_profile) module, which adds a `profile` entity to farmOS instances. However, because profiles are not yet an official part of core, we needed to enable a way for farmOS.js consumers to define their own entities. I had very roughly implemented this functionality but had never properly tested it, so it was not a huge surprise it didn't really work. More could still be done to document this and annotate the types, but I'm holding off on that until we've put this through the paces a little more rigorously.

There should also be more tests, but for right now, due to time constraints, I'm just pushing a separate branch on my fork, with [the script I used for testing](https://github.com/jgaehring/farmOS.js/blob/profile-support-test/test/profile-support.js). In due time that might be a starting point for more tests, and maybe an example for the docs.

I will likely make use of this feature in Field Kit, too, so I can add images there w/o first addressing #47. Then I can circle back and implement files in farmOS.js based on what I learn "in the wild". That may be the best time to solidify the docs, types, tests, etc.