### PR TITLE
beta.12 Release Candidate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/**
 dist/**
 report.json
 errors.json
+.env

--- a/core_schemata/update-script.js
+++ b/core_schemata/update-script.js
@@ -1,5 +1,5 @@
 const farmOS = require('../dist/cjs/farmOS').default;
-const localServerConfig = require('../local-server-config.js');
+const localServerConfig = require('../test/local-server-config.js');
 const { writeSchema } = require('./fs-utils.js');
 
 const $idURI = (entity, bundle) =>

--- a/docs/api.md
+++ b/docs/api.md
@@ -49,6 +49,9 @@ associated metadata and schemata.</p>
 <dd><p>The methods for transmitting farmOS data structures, such as assets, logs,
 etc, to a farmOS server.</p>
 </dd>
+<dt><a href="#FetchSchema">FetchSchema</a> ⇒ <code>Promise.&lt;(EntitySchemata|BundleSchemata|JsonSchema)&gt;</code></dt>
+<dd><p>Fetch JSON Schema documents for farmOS data structures.</p>
+</dd>
 <dt><a href="#AuthMixin">AuthMixin</a> ⇒ <code>Object.&lt;string, function()&gt;</code></dt>
 <dd></dd>
 <dt><a href="#FarmClient">FarmClient</a> : <code>Object</code></dt>
@@ -279,6 +282,18 @@ etc, to a farmOS server.
 | send | <code>sendEntity</code> | 
 | delete | <code>deleteEntity</code> | 
 
+<a name="FetchSchema"></a>
+
+## FetchSchema ⇒ <code>Promise.&lt;(EntitySchemata\|BundleSchemata\|JsonSchema)&gt;</code>
+Fetch JSON Schema documents for farmOS data structures.
+
+**Kind**: global typedef  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| [entity] | <code>string</code> | The farmOS entity for which you wish to retrieve schemata. |
+| [bundle] | <code>string</code> | The entity bundle for which you wish to retrieve schemata. |
+
 <a name="AuthMixin"></a>
 
 ## AuthMixin ⇒ <code>Object.&lt;string, function()&gt;</code>
@@ -311,7 +326,7 @@ from a farmOS Drupal 9 server using JSON:API.
 | [getToken] | <code>function</code> | 
 | info | <code>function</code> | 
 | schema | <code>Object</code> | 
-| schema.fetch | <code>function</code> | 
+| schema.fetch | [<code>FetchSchema</code>](#FetchSchema) | 
 | asset | [<code>ClientEntityMethods</code>](#ClientEntityMethods) | 
 | log | [<code>ClientEntityMethods</code>](#ClientEntityMethods) | 
 | plan | [<code>ClientEntityMethods</code>](#ClientEntityMethods) | 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,6 @@
 # Introduction
+## ⚠️ __WARNING: EXPERIMENTAL!__ ⚠️
+__PLEASE READ:__ As farmOS.js version 2.0.0 approaches its general release, be aware that there have recently been, and may continue to be, breaking changes in the `beta.x` releases. Most notably, the `2.0.0-beta.12` contains [several breaking changes](https://github.com/farmOS/farmOS.js/pull/70). It is advised that if you use any of these beta releases you be careful to pin your dependencies to an exact version number in your `package.json` file's dependencies.
 
 ## Motivation
 farmOS.js is a JavaScript library for working with farmOS data structures and interacting with farmOS servers.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "farmos",
-  "version": "2.0.0-beta.11",
+  "version": "2.0.0-beta.12",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "farmos",
-      "version": "2.0.0-beta.11",
+      "version": "2.0.0-beta.12",
       "license": "MIT",
       "dependencies": {
         "axios": "^0.25.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "chai": "^4.2.0",
         "chai-as-promised": "^7.1.1",
         "chai-string": "^1.5.0",
+        "dotenv": "^16.0.3",
         "eslint": "^8.7.0",
         "eslint-config-airbnb-base": "^15.0.0",
         "eslint-plugin-import": "^2.25.4",
@@ -934,6 +935,15 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.3.tgz",
+      "integrity": "sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/emoji-regex": {
@@ -2291,9 +2301,9 @@
       "dev": true
     },
     "node_modules/minimatch": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "dev": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -2327,9 +2337,9 @@
       "dev": true
     },
     "node_modules/mocha": {
-      "version": "9.2.0",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-9.2.0.tgz",
-      "integrity": "sha512-kNn7E8g2SzVcq0a77dkphPsDSN7P+iYkqE0ZsGCYWRsoiKjOt+NvXfaagik8vuDa6W5Zw3qxe8Jfpt5qKf+6/Q==",
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-9.2.2.tgz",
+      "integrity": "sha512-L6XC3EdwT6YrIk0yXpavvLkn8h+EU+Y5UcCHKECyMbdUIxyMuZj4bX4U9e1nvnvUUvQVsV2VHQr5zLdcUkhW/g==",
       "dev": true,
       "dependencies": {
         "@ungap/promise-all-settled": "1.1.2",
@@ -2345,9 +2355,9 @@
         "he": "1.2.0",
         "js-yaml": "4.1.0",
         "log-symbols": "4.1.0",
-        "minimatch": "3.0.4",
+        "minimatch": "4.2.1",
         "ms": "2.1.3",
-        "nanoid": "3.2.0",
+        "nanoid": "3.3.1",
         "serialize-javascript": "6.0.0",
         "strip-json-comments": "3.1.1",
         "supports-color": "8.1.1",
@@ -2398,6 +2408,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mocha/node_modules/minimatch": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-4.2.1.tgz",
+      "integrity": "sha512-9Uq1ChtSZO+Mxa/CL1eGizn2vRn3MlLgzhT0Iz8zaY8NdvxvB0d5QdPFmCKf7JKA9Lerx5vRrnwO03jsSfGG9g==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/mocha/node_modules/ms": {
@@ -2467,9 +2489,9 @@
       "dev": true
     },
     "node_modules/nanoid": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.2.0.tgz",
-      "integrity": "sha512-fmsZYa9lpn69Ad5eDn7FMcnnSR+8R34W9qJEijxYhTbfOWzr22n1QxCMzXLK+ODyW2973V3Fux959iQoUxzUIA==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.1.tgz",
+      "integrity": "sha512-n6Vs/3KGyxPQd6uO0eH4Bv0ojGSUvuLlIHtC3Y0kEO23YRge8H9x1GCzLn28YX0H66pMkxuaeESFq4tKISKwdw==",
       "dev": true,
       "bin": {
         "nanoid": "bin/nanoid.cjs"
@@ -4266,6 +4288,12 @@
         "esutils": "^2.0.2"
       }
     },
+    "dotenv": {
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.3.tgz",
+      "integrity": "sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ==",
+      "dev": true
+    },
     "emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
@@ -5281,9 +5309,9 @@
       "dev": true
     },
     "minimatch": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
@@ -5308,9 +5336,9 @@
       "dev": true
     },
     "mocha": {
-      "version": "9.2.0",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-9.2.0.tgz",
-      "integrity": "sha512-kNn7E8g2SzVcq0a77dkphPsDSN7P+iYkqE0ZsGCYWRsoiKjOt+NvXfaagik8vuDa6W5Zw3qxe8Jfpt5qKf+6/Q==",
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-9.2.2.tgz",
+      "integrity": "sha512-L6XC3EdwT6YrIk0yXpavvLkn8h+EU+Y5UcCHKECyMbdUIxyMuZj4bX4U9e1nvnvUUvQVsV2VHQr5zLdcUkhW/g==",
       "dev": true,
       "requires": {
         "@ungap/promise-all-settled": "1.1.2",
@@ -5326,9 +5354,9 @@
         "he": "1.2.0",
         "js-yaml": "4.1.0",
         "log-symbols": "4.1.0",
-        "minimatch": "3.0.4",
+        "minimatch": "4.2.1",
         "ms": "2.1.3",
-        "nanoid": "3.2.0",
+        "nanoid": "3.3.1",
         "serialize-javascript": "6.0.0",
         "strip-json-comments": "3.1.1",
         "supports-color": "8.1.1",
@@ -5356,6 +5384,15 @@
           "dev": true,
           "requires": {
             "p-locate": "^5.0.0"
+          }
+        },
+        "minimatch": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-4.2.1.tgz",
+          "integrity": "sha512-9Uq1ChtSZO+Mxa/CL1eGizn2vRn3MlLgzhT0Iz8zaY8NdvxvB0d5QdPFmCKf7JKA9Lerx5vRrnwO03jsSfGG9g==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^1.1.7"
           }
         },
         "ms": {
@@ -5406,9 +5443,9 @@
       "dev": true
     },
     "nanoid": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.2.0.tgz",
-      "integrity": "sha512-fmsZYa9lpn69Ad5eDn7FMcnnSR+8R34W9qJEijxYhTbfOWzr22n1QxCMzXLK+ODyW2973V3Fux959iQoUxzUIA==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.1.tgz",
+      "integrity": "sha512-n6Vs/3KGyxPQd6uO0eH4Bv0ojGSUvuLlIHtC3Y0kEO23YRge8H9x1GCzLn28YX0H66pMkxuaeESFq4tKISKwdw==",
       "dev": true
     },
     "natural-compare": {

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
     "chai-string": "^1.5.0",
+    "dotenv": "^16.0.3",
     "eslint": "^8.7.0",
     "eslint-config-airbnb-base": "^15.0.0",
     "eslint-plugin-import": "^2.25.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "farmos",
-  "version": "2.0.0-beta.11",
+  "version": "2.0.0-beta.12",
   "description": "A JavaScript library for working with farmOS data structures and interacting with farmOS servers.",
   "main": "dist/cjs/farmOS.js",
   "module": "dist/esm/farmOS.js",

--- a/test/client/client.js
+++ b/test/client/client.js
@@ -1,5 +1,5 @@
 const client = require('../../dist/cjs/client').default;
-const localServerConfig = require('../../local-server-config');
+const localServerConfig = require('../local-server-config');
 
 const {
   host, clientId, username, password,

--- a/test/client/user.js
+++ b/test/client/user.js
@@ -1,5 +1,5 @@
 const chai = require('chai');
-const localServerConfig = require('../../local-server-config');
+const localServerConfig = require('../local-server-config');
 const { reportError } = require('../report');
 const { farm, session } = require('./client');
 

--- a/test/index.js
+++ b/test/index.js
@@ -1,7 +1,7 @@
 const chai = require('chai');
 const chaiAsPromised = require('chai-as-promised');
 const farmOS = require('../dist/cjs/farmOS').default;
-const localServerConfig = require('../local-server-config');
+const localServerConfig = require('./local-server-config');
 const { reportError } = require('./report');
 
 chai.use(chaiAsPromised);

--- a/test/local-server-config.js
+++ b/test/local-server-config.js
@@ -1,8 +1,10 @@
+require('dotenv').config();
+
 // These are the parameters required to connect to the local server used by
 // tests and scripts in both the development and CI environments.
 module.exports = {
   host: 'http://localhost',
   clientId: 'fieldkit',
-  username: 'admin',
-  password: 'admin',
+  username: process.env.TEST_USERNAME || 'admin',
+  password: process.env.TEST_USERNAME || 'admin',
 };

--- a/test/subrequest.js
+++ b/test/subrequest.js
@@ -2,7 +2,7 @@ const chai = require('chai');
 const { mergeRight } = require('ramda');
 const farmOS = require('../dist/cjs/farmOS').default;
 const { useSubrequests } = require('../dist/cjs/farmOS');
-const localServerConfig = require('../local-server-config');
+const localServerConfig = require('./local-server-config');
 const { reportError } = require('./report');
 
 const { expect } = chai;


### PR DESCRIPTION
As farmOS.js version 2.0.0 approaches its general release, be aware that there have recently been, and may continue to be, breaking changes in the `beta.x` releases, particularly this one. It is advised that if consumers of this library use any of these beta releases they should be careful to pin their dependencies to an exact version number in your `package.json` file's dependencies.

A version of the above statement was added to the docs in 717715a61bdc54231059f3b61f7eea38049f7351, linking to this pull request. For reference, the specific breaking changes are outlined in the preceding 3 pull requests:

- #67 
- #68 
- #69 
